### PR TITLE
assume dot is on path

### DIFF
--- a/gv-core/jvm/src/main/scala/uk/co/turingatemyhamster/graphvizs/exec/Exec.scala
+++ b/gv-core/jvm/src/main/scala/uk/co/turingatemyhamster/graphvizs/exec/Exec.scala
@@ -17,6 +17,12 @@ import javax.xml.parsers.SAXParserFactory
  * @author Matthew Pocock
  */
 
+object Exec {
+  def apply(binary: File) = new Exec { 
+    val dotBinary = binary 
+  }
+}
+
 trait Exec extends GraphHandlers with StringHandlers with FileHandlers {
 
   /**

--- a/gv-core/jvm/src/test/scala/uk/co/turingatemyhamster/graphvizs/dsl/ExecSpec.scala
+++ b/gv-core/jvm/src/test/scala/uk/co/turingatemyhamster/graphvizs/dsl/ExecSpec.scala
@@ -4,6 +4,7 @@ import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
 
 import uk.co.turingatemyhamster.graphvizs.exec._
+import java.io.File
 
 
 /**
@@ -61,6 +62,13 @@ class ExecSpec extends Specification {
 
     val annotated = gOut.statements.collect { case es@EdgeStatement(_, _, Some(_)) => es }
     ! annotated.isEmpty
+  }
+
+  "allow dot location to be overriden" in {
+    val path = new File("/usr/local/bin/doc")
+    val customExec = Exec(path)
+    import customExec._
+    dotBinary ==== path
   }
 
 //  "run DOT on graph input and generate SVG XML output" in {


### PR DESCRIPTION
On my local machine, dot is at `/usr/local/bin/dot`. If it is safe to assume that dot is on the path and executable, I don't see a problem with referencing it directly.
