### PR TITLE
Added patchwork layout

### DIFF
--- a/gv-core/jvm/src/main/scala/uk/co/turingatemyhamster/graphvizs/exec/Exec.scala
+++ b/gv-core/jvm/src/main/scala/uk/co/turingatemyhamster/graphvizs/exec/Exec.scala
@@ -116,7 +116,7 @@ trait GraphHandlers {
     var value: Graph = null
 
     def handle(out: InputStream) {
-      value = dsl.parseAsGraph(Source.fromInputStream(out).mkString)
+      value = dsl.parseAsGraph(Source.fromInputStream(out).mkString.trim())
       out.close()
     }
   }

--- a/gv-core/shared/src/main/scala/uk/co/turingatemyhamster/graphvizs/exec/DotLayout.scala
+++ b/gv-core/shared/src/main/scala/uk/co/turingatemyhamster/graphvizs/exec/DotLayout.scala
@@ -14,8 +14,9 @@ object DotLayout {
   val circo = DotLayout("circo")
   val fdp   = DotLayout("fdp")
   val sfdp  = DotLayout("sfdp")
+  val patchwork  = DotLayout("patchwork")
 
   val allLayouts = Seq(
-    dot, neato, twopi, circo, fdp, sfdp
+    dot, neato, twopi, circo, fdp, sfdp, patchwork
   )
 }


### PR DESCRIPTION
According to the documentation, it builds a treemap:

> patchwork  draws  the  graph  as  a squarified treemap (see M. Bruls et al., "Squarified treemaps", Proc. Joint Eurographics and IEEE TCVG  Symp.  on Visualization,  2000,  pp. 33-42). The clusters of the graph are used to specify the tree.

Also fixed a parsing issue related to a dangling return character in the output under Linux.